### PR TITLE
chore: add Vienna design system demos

### DIFF
--- a/Backend/public/design/index.html
+++ b/Backend/public/design/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Flowerchino – Design</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Inter', 'Segoe UI', sans-serif;
+      background: #F5EDD8;
+      color: #18120A;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 1.5rem;
+      gap: 2rem;
+    }
+    .logo { font-size: 2rem; font-weight: 800; letter-spacing: -0.03em; color: #2C5530; }
+    .logo span { color: #C8A030; }
+    .subtitle { color: #7A6040; font-size: 0.9rem; }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      width: 100%;
+      max-width: 620px;
+    }
+
+    .card {
+      border-radius: 14px; overflow: hidden;
+      border: 2px solid #CFC0A0;
+      text-decoration: none;
+      transition: transform 0.2s, border-color 0.2s;
+      display: block;
+    }
+    .card:hover { transform: translateY(-4px); border-color: #2C5530; }
+
+    .card-preview {
+      height: 160px;
+      background: #EDE0C5;
+      display: flex; flex-direction: column;
+      padding: 1rem; gap: 0.5rem;
+    }
+    .mock-topbar { background: #2C5530; height: 22px; border-radius: 4px; width: 100%; }
+    .mock-hero { background: #EDE0C5; border: 2px solid #C8A030; height: 40px; border-radius: 6px; }
+    .mock-body { display: flex; gap: 8px; flex: 1; }
+    .mock-sidebar { background: #EDE0C5; border: 1px solid #CFC0A0; border-radius: 4px; width: 40px; }
+    .mock-content { flex: 1; display: flex; flex-direction: column; gap: 5px; }
+    .mock-row { background: #F5EDD8; border: 1px solid #CFC0A0; border-radius: 4px; flex: 1; }
+    .mock-row.accent { border-left: 3px solid #C8A030; }
+
+    .card-info { background: #2C5530; padding: 1rem 1.25rem; }
+    .card-name { font-weight: 700; font-size: 1rem; margin-bottom: 0.2rem; color: #fff; }
+    .card-desc { font-size: 0.78rem; color: rgba(255,255,255,0.55); }
+    .swatches { display: flex; gap: 5px; margin-top: 0.65rem; }
+    .swatch { width: 18px; height: 18px; border-radius: 50%; }
+
+    footer { color: #CFC0A0; font-size: 0.78rem; }
+  </style>
+</head>
+<body>
+
+  <div>
+    <div class="logo">flower<span>chino</span></div>
+    <div class="subtitle" style="text-align:center; margin-top:0.25rem;">Vienna · Selected Design</div>
+  </div>
+
+  <div class="grid">
+    <a class="card" href="palette-9-vienna.html">
+      <div class="card-preview">
+        <div class="mock-topbar"></div>
+        <div class="mock-hero"></div>
+        <div class="mock-content" style="flex-direction:row; gap:6px; flex:1; margin-top:4px;">
+          <div class="mock-row accent"></div>
+          <div class="mock-row accent"></div>
+          <div class="mock-row accent"></div>
+        </div>
+      </div>
+      <div class="card-info">
+        <div class="card-name">Vienna — Scroll</div>
+        <div class="card-desc">Single column, top-to-bottom flow.</div>
+        <div class="swatches">
+          <div class="swatch" style="background:#2C5530"></div>
+          <div class="swatch" style="background:#7A4820"></div>
+          <div class="swatch" style="background:#C8A030"></div>
+          <div class="swatch" style="background:#F5EDD8; border:1px solid #CFC0A0"></div>
+        </div>
+      </div>
+    </a>
+
+    <a class="card" href="palette-9-vienna-v2.html">
+      <div class="card-preview">
+        <div class="mock-topbar"></div>
+        <div class="mock-hero"></div>
+        <div class="mock-body" style="margin-top:4px;">
+          <div class="mock-sidebar"></div>
+          <div class="mock-content">
+            <div class="mock-row accent"></div>
+            <div class="mock-row accent"></div>
+            <div class="mock-row"></div>
+          </div>
+        </div>
+      </div>
+      <div class="card-info">
+        <div class="card-name">Vienna — Sidebar</div>
+        <div class="card-desc">Two-column layout with side navigation.</div>
+        <div class="swatches">
+          <div class="swatch" style="background:#2C5530"></div>
+          <div class="swatch" style="background:#7A4820"></div>
+          <div class="swatch" style="background:#C8A030"></div>
+          <div class="swatch" style="background:#F5EDD8; border:1px solid #CFC0A0"></div>
+        </div>
+      </div>
+    </a>
+  </div>
+
+  <footer>© 2026 Flowerchino · Elastic License 2.0</footer>
+
+</body>
+</html>

--- a/Backend/public/design/palette-9-vienna-v2.html
+++ b/Backend/public/design/palette-9-vienna-v2.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Flowerchino – Vienna v2</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --primary:    #2C5530;
+      --secondary:  #7A4820;
+      --accent:     #C8A030;
+      --bg:         #F5EDD8;
+      --surface:    #EDE0C5;
+      --surface2:   #E2D3B0;
+      --text:       #18120A;
+      --text-muted: #7A6040;
+      --border:     #CFC0A0;
+    }
+
+    body {
+      font-family: 'Inter', 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ── TOP BAR ── */
+    .topbar {
+      background: var(--primary);
+      height: 52px;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0 1.5rem;
+      flex-shrink: 0;
+    }
+    .logo { font-size: 1.25rem; font-weight: 800; letter-spacing: -0.02em; color: #fff; }
+    .logo span { color: var(--accent); }
+    .topbar-right { display: flex; align-items: center; gap: 1.25rem; }
+    .topbar-right a { color: rgba(255,255,255,0.6); text-decoration: none; font-size: 0.82rem; font-weight: 500; }
+    .topbar-right a:hover { color: var(--accent); }
+    .btn-login {
+      background: var(--accent); color: var(--primary);
+      padding: 0.3rem 0.9rem; border-radius: 5px; font-weight: 800;
+      font-size: 0.8rem; text-decoration: none;
+    }
+
+    /* ── BREADCRUMB ── */
+    .breadcrumb {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 0.55rem 1.5rem;
+      font-size: 0.78rem; color: var(--text-muted);
+      display: flex; align-items: center; gap: 0.4rem;
+    }
+    .breadcrumb a { color: var(--secondary); text-decoration: none; font-weight: 600; }
+    .breadcrumb a:hover { text-decoration: underline; }
+
+    /* ── PLANT HEADER ── */
+    .plant-header {
+      background: var(--surface);
+      border-bottom: 3px solid var(--accent);
+      padding: 1.25rem 1.5rem;
+    }
+    .plant-header-inner {
+      display: flex; align-items: center; gap: 1.25rem;
+    }
+    .plant-icon {
+      width: 72px; height: 72px; border-radius: 10px;
+      background: var(--bg); border: 2px solid var(--border);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 2.5rem; flex-shrink: 0;
+    }
+    .plant-title h1 { font-size: 1.75rem; font-weight: 800; letter-spacing: -0.02em; color: var(--primary); }
+    .plant-title .binomial { font-style: italic; color: var(--secondary); font-size: 0.95rem; margin-top: 0.1rem; }
+    .badges { display: flex; gap: 0.45rem; flex-wrap: wrap; margin-top: 0.55rem; }
+    .badge { font-size: 0.7rem; padding: 0.2rem 0.65rem; border-radius: 4px; font-weight: 700; }
+    .badge-verified { background: rgba(44,85,48,0.12); color: var(--primary); border: 1px solid rgba(44,85,48,0.3); }
+    .badge-family { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); }
+    .badge-hydro { background: rgba(200,160,48,0.15); color: #8A6800; border: 1px solid rgba(200,160,48,0.35); }
+
+    /* ── BODY LAYOUT ── */
+    .body-layout {
+      display: flex;
+      flex: 1;
+    }
+
+    /* ── SIDEBAR ── */
+    .sidebar {
+      width: 200px;
+      flex-shrink: 0;
+      background: var(--surface);
+      border-right: 1px solid var(--border);
+      padding: 1.25rem 0;
+    }
+    .sidebar-section { margin-bottom: 1.5rem; }
+    .sidebar-label {
+      font-size: 0.6rem; font-weight: 800; text-transform: uppercase;
+      letter-spacing: 0.14em; color: var(--text-muted);
+      padding: 0 1rem; margin-bottom: 0.4rem;
+    }
+    .sidebar-item {
+      display: block; padding: 0.45rem 1rem;
+      font-size: 0.82rem; font-weight: 600; color: var(--text-muted);
+      text-decoration: none; cursor: pointer;
+      border-left: 3px solid transparent;
+      transition: all 0.12s;
+    }
+    .sidebar-item:hover { color: var(--text); background: var(--surface2); }
+    .sidebar-item.active {
+      color: var(--primary); background: rgba(44,85,48,0.08);
+      border-left-color: var(--primary); font-weight: 700;
+    }
+
+    /* ── MAIN CONTENT ── */
+    .main-content {
+      flex: 1;
+      padding: 1.5rem;
+      overflow: auto;
+    }
+
+    /* ── STAGE TABS ── */
+    .stage-row {
+      display: flex; align-items: center; gap: 0.35rem;
+      margin-bottom: 1.5rem; flex-wrap: wrap;
+    }
+    .stage-label { font-size: 0.7rem; font-weight: 700; color: var(--text-muted); margin-right: 0.25rem; text-transform: uppercase; letter-spacing: 0.1em; }
+    .tab {
+      font-size: 0.75rem; padding: 0.3rem 0.9rem;
+      border-radius: 5px; border: 1px solid var(--border);
+      background: var(--bg); color: var(--text-muted);
+      cursor: pointer; font-weight: 600; transition: all 0.12s;
+    }
+    .tab.active { background: var(--primary); color: #fff; border-color: var(--primary); }
+    .tab:hover:not(.active) { border-color: var(--secondary); color: var(--secondary); }
+
+    /* ── TWO-COLUMN GRID ── */
+    .two-col { display: grid; grid-template-columns: 1fr 320px; gap: 1.25rem; }
+
+    /* ── SECTION HEADING ── */
+    .section-title {
+      font-size: 0.65rem; font-weight: 800; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--text-muted); margin-bottom: 0.9rem;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .section-title::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+
+    /* ── PARAM GRID ── */
+    .param-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 0.6rem; margin-bottom: 1.5rem; }
+    .param-card {
+      background: var(--bg);
+      border-radius: 8px; padding: 0.8rem;
+      border: 1px solid var(--border);
+      border-left: 3px solid var(--accent);
+      transition: box-shadow 0.15s;
+    }
+    .param-card:hover { box-shadow: 0 2px 10px rgba(122,72,32,0.1); }
+    .param-label { font-size: 0.62rem; color: var(--text-muted); margin-bottom: 0.3rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
+    .param-value { font-size: 1.1rem; font-weight: 800; color: var(--primary); letter-spacing: -0.02em; }
+    .param-unit { font-size: 0.65rem; color: var(--text-muted); }
+
+    /* ── NUTRIENT BARS ── */
+    .nutrient-section { margin-bottom: 1.5rem; }
+    .nutrient-row { display: flex; align-items: center; gap: 0.85rem; margin-bottom: 0.6rem; font-size: 0.83rem; }
+    .nutrient-label { width: 26px; font-weight: 800; color: var(--secondary); }
+    .nutrient-bar-bg { flex: 1; height: 7px; background: var(--surface2); border-radius: 4px; overflow: hidden; }
+    .nutrient-bar { height: 100%; background: linear-gradient(90deg, var(--primary), var(--accent)); border-radius: 4px; }
+    .nutrient-val { width: 66px; text-align: right; color: var(--text-muted); font-size: 0.78rem; font-weight: 600; }
+
+    /* ── SYSTEM CHIPS ── */
+    .systems { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+    .system-chip { font-size: 0.75rem; padding: 0.3rem 0.8rem; border-radius: 5px; font-weight: 700; }
+    .system-yes { background: rgba(44,85,48,0.1); color: var(--primary); border: 1px solid rgba(44,85,48,0.25); }
+    .system-no  { background: var(--surface); color: var(--border); border: 1px solid var(--border); text-decoration: line-through; }
+
+    /* ── RIGHT PANEL CARDS ── */
+    .panel-card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 10px; padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .panel-card-title {
+      font-size: 0.7rem; font-weight: 800; text-transform: uppercase;
+      letter-spacing: 0.12em; color: var(--text-muted);
+      margin-bottom: 0.85rem; padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* ── TAXONOMY ── */
+    .tax-row { display: flex; gap: 0.75rem; font-size: 0.82rem; padding: 0.3rem 0; border-bottom: 1px solid var(--surface2); }
+    .tax-row:last-child { border-bottom: none; }
+    .tax-key { width: 80px; color: var(--text-muted); font-weight: 600; font-size: 0.78rem; }
+    .tax-val { font-weight: 700; color: var(--text); }
+
+    /* ── QUALITY ── */
+    .quality-score { font-size: 2rem; font-weight: 800; color: var(--accent); letter-spacing: -0.03em; }
+    .quality-bar-bg { background: var(--surface2); border-radius: 4px; height: 7px; margin: 0.4rem 0; }
+    .quality-bar-fill { height: 100%; border-radius: 4px; background: var(--accent); width: 72%; }
+    .quality-meta { font-size: 0.72rem; color: var(--text-muted); line-height: 1.5; }
+
+    /* ── COMMUNITY ── */
+    .comment { display: flex; gap: 0.65rem; margin-bottom: 0.8rem; }
+    .avatar {
+      width: 32px; height: 32px; border-radius: 50%;
+      background: var(--secondary); display: flex; align-items: center;
+      justify-content: center; font-weight: 800; font-size: 0.72rem;
+      color: #fff; flex-shrink: 0;
+    }
+    .comment-body { background: var(--surface); border-radius: 7px; padding: 0.5rem 0.75rem; border: 1px solid var(--border); font-size: 0.8rem; flex: 1; }
+    .comment-meta { font-size: 0.68rem; color: var(--text-muted); margin-bottom: 0.15rem; }
+
+    /* ── FOOTER ── */
+    footer {
+      background: var(--primary);
+      color: rgba(255,255,255,0.45);
+      text-align: center; padding: 1rem;
+      font-size: 0.75rem;
+      border-top: 3px solid var(--accent);
+    }
+    footer span { color: var(--accent); font-weight: 700; }
+  </style>
+</head>
+<body>
+
+<div class="topbar">
+  <div class="logo">flower<span>chino</span></div>
+  <div class="topbar-right">
+    <a href="#">Plants</a>
+    <a href="#">API</a>
+    <a href="#">Community</a>
+    <a class="btn-login" href="#">Login</a>
+  </div>
+</div>
+
+<div class="breadcrumb">
+  <a href="#">Plants</a> › <a href="#">Solanaceae</a> › <a href="#">Solanum</a> › Solanum lycopersicum
+</div>
+
+<div class="plant-header">
+  <div class="plant-header-inner">
+    <div class="plant-icon">🍅</div>
+    <div class="plant-title">
+      <h1>Tomato</h1>
+      <div class="binomial">Solanum lycopersicum L.</div>
+      <div class="badges">
+        <span class="badge badge-verified">✓ Community Verified</span>
+        <span class="badge badge-family">Solanaceae</span>
+        <span class="badge badge-hydro">Hydroponics</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="body-layout">
+
+  <aside class="sidebar">
+    <div class="sidebar-section">
+      <div class="sidebar-label">Growth Stage</div>
+      <a class="sidebar-item">Germinating</a>
+      <a class="sidebar-item">Seedling</a>
+      <a class="sidebar-item">Vegetative</a>
+      <a class="sidebar-item active">Flowering</a>
+      <a class="sidebar-item">Fruiting</a>
+      <a class="sidebar-item">Harvesting</a>
+    </div>
+    <div class="sidebar-section">
+      <div class="sidebar-label">Sections</div>
+      <a class="sidebar-item">Parameters</a>
+      <a class="sidebar-item">Nutrients</a>
+      <a class="sidebar-item">Systems</a>
+      <a class="sidebar-item">Taxonomy</a>
+      <a class="sidebar-item">Community</a>
+    </div>
+  </aside>
+
+  <div class="main-content">
+    <div class="two-col">
+
+      <div>
+        <div class="section-title">Hydroponics Parameters</div>
+        <div class="param-grid">
+          <div class="param-card"><div class="param-label">pH</div><div class="param-value">5.8–6.2</div></div>
+          <div class="param-card"><div class="param-label">EC</div><div class="param-value">2.5–3.5</div><div class="param-unit">mS/cm</div></div>
+          <div class="param-card"><div class="param-label">TDS</div><div class="param-value">1250–1750</div><div class="param-unit">ppm</div></div>
+          <div class="param-card"><div class="param-label">Water Temp</div><div class="param-value">18–22</div><div class="param-unit">°C</div></div>
+          <div class="param-card"><div class="param-label">Air Temp</div><div class="param-value">20–26</div><div class="param-unit">°C</div></div>
+          <div class="param-card"><div class="param-label">Humidity</div><div class="param-value">50–65</div><div class="param-unit">%</div></div>
+          <div class="param-card"><div class="param-label">VPD</div><div class="param-value">1.0–1.5</div><div class="param-unit">kPa</div></div>
+          <div class="param-card"><div class="param-label">PPFD</div><div class="param-value">500–700</div><div class="param-unit">µmol/m²/s</div></div>
+          <div class="param-card"><div class="param-label">Photoperiod</div><div class="param-value">16</div><div class="param-unit">hours</div></div>
+          <div class="param-card"><div class="param-label">DO</div><div class="param-value">≥ 8</div><div class="param-unit">mg/L</div></div>
+        </div>
+
+        <div class="section-title">Nutrient Profile</div>
+        <div class="nutrient-section">
+          <div class="nutrient-row"><span class="nutrient-label">N</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:55%"></div></div><span class="nutrient-val">120 ppm</span></div>
+          <div class="nutrient-row"><span class="nutrient-label">P</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:35%"></div></div><span class="nutrient-val">70 ppm</span></div>
+          <div class="nutrient-row"><span class="nutrient-label">K</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:90%"></div></div><span class="nutrient-val">250 ppm</span></div>
+          <div class="nutrient-row"><span class="nutrient-label">Ca</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:65%"></div></div><span class="nutrient-val">160 ppm</span></div>
+          <div class="nutrient-row"><span class="nutrient-label">Mg</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:25%"></div></div><span class="nutrient-val">50 ppm</span></div>
+        </div>
+
+        <div class="section-title">Grow System Compatibility</div>
+        <div class="systems">
+          <span class="system-chip system-yes">✓ DWC</span>
+          <span class="system-chip system-yes">✓ NFT</span>
+          <span class="system-chip system-yes">✓ Drip</span>
+          <span class="system-chip system-yes">✓ Ebb &amp; Flow</span>
+          <span class="system-chip system-no">Kratky</span>
+          <span class="system-chip system-no">Wicking</span>
+        </div>
+
+        <div class="section-title">Community</div>
+        <div class="comment">
+          <div class="avatar">MG</div>
+          <div class="comment-body"><div class="comment-meta">MaxGrower · 2 days ago</div>EC during late flowering can go up to 4.0 without stress if you ramp slowly over a week.</div>
+        </div>
+        <div class="comment">
+          <div class="avatar">SH</div>
+          <div class="comment-body"><div class="comment-meta">SarahHydro · 1 day ago</div>Confirmed. I run 3.8 in fruiting stage, massive yield difference compared to 2.5.</div>
+        </div>
+      </div>
+
+      <div>
+        <div class="panel-card">
+          <div class="panel-card-title">Taxonomy</div>
+          <div class="tax-row"><span class="tax-key">Kingdom</span><span class="tax-val">Plantae</span></div>
+          <div class="tax-row"><span class="tax-key">Family</span><span class="tax-val">Solanaceae</span></div>
+          <div class="tax-row"><span class="tax-key">Genus</span><span class="tax-val">Solanum</span></div>
+          <div class="tax-row"><span class="tax-key">Species</span><span class="tax-val">S. lycopersicum</span></div>
+          <div class="tax-row"><span class="tax-key">IPNI ID</span><span class="tax-val">320035-2</span></div>
+          <div class="tax-row"><span class="tax-key">GBIF Key</span><span class="tax-val">5284517</span></div>
+        </div>
+
+        <div class="panel-card">
+          <div class="panel-card-title">Data Quality</div>
+          <div class="quality-score">72%</div>
+          <div class="quality-bar-bg"><div class="quality-bar-fill"></div></div>
+          <div class="quality-meta">Community Verified<br>Last reviewed 3 days ago · 12 contributors</div>
+        </div>
+
+        <div class="panel-card" style="background: var(--primary); border-color: var(--primary);">
+          <div class="panel-card-title" style="color: rgba(255,255,255,0.5); border-color: rgba(255,255,255,0.15);">Contribute</div>
+          <p style="font-size:0.82rem; color: rgba(255,255,255,0.75); margin-bottom:0.85rem; line-height:1.5;">Help improve this entry by suggesting corrections or adding missing data.</p>
+          <a href="#" style="display:inline-block; background:var(--accent); color:var(--primary); font-size:0.78rem; font-weight:800; padding:0.45rem 1rem; border-radius:5px; text-decoration:none;">Suggest Edit</a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<footer>© 2026 <span>Flowerchino</span> · Elastic License 2.0</footer>
+</body>
+</html>

--- a/Backend/public/design/palette-9-vienna.html
+++ b/Backend/public/design/palette-9-vienna.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Flowerchino – Vienna</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --primary:    #2C5530;
+      --secondary:  #7A4820;
+      --accent:     #C8A030;
+      --bg:         #F5EDD8;
+      --surface:    #EDE0C5;
+      --surface2:   #E2D3B0;
+      --text:       #18120A;
+      --text-muted: #7A6040;
+      --border:     #CFC0A0;
+    }
+
+    body { font-family: 'Inter', 'Segoe UI', sans-serif; background: var(--bg); color: var(--text); }
+
+    nav {
+      background: var(--primary);
+      padding: 0 2rem;
+      display: flex; align-items: center; justify-content: space-between;
+      height: 64px;
+    }
+    .logo { font-size: 1.4rem; font-weight: 800; letter-spacing: -0.02em; color: #fff; }
+    .logo span { color: var(--accent); }
+    nav ul { list-style: none; display: flex; gap: 2rem; align-items: center; }
+    nav ul a { color: rgba(255,255,255,0.65); text-decoration: none; font-size: 0.85rem; font-weight: 500; }
+    nav ul a:hover { color: var(--accent); }
+    .nav-login {
+      background: var(--accent); color: var(--primary) !important;
+      padding: 0.4rem 1.1rem; border-radius: 6px; font-weight: 800 !important;
+    }
+
+    .hero {
+      background: var(--surface);
+      padding: 3.5rem 2rem 2.5rem;
+      border-bottom: 3px solid var(--accent);
+      position: relative;
+    }
+    .hero::after {
+      content: '';
+      position: absolute; left: 0; right: 0; bottom: -3px; height: 1px;
+      background: linear-gradient(90deg, transparent, rgba(200,160,48,0.5), transparent);
+    }
+    .hero-inner { max-width: 900px; margin: 0 auto; display: flex; gap: 2rem; align-items: center; }
+    .plant-icon {
+      width: 92px; height: 92px; border-radius: 12px;
+      background: var(--bg);
+      border: 2px solid var(--border);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 3rem; flex-shrink: 0;
+    }
+    .hero-meta { flex: 1; }
+    .hero-meta h1 { font-size: 2.2rem; font-weight: 800; margin-bottom: 0.2rem; letter-spacing: -0.03em; color: var(--primary); }
+    .hero-meta .binomial { font-style: italic; color: var(--secondary); font-size: 1.05rem; margin-bottom: 0.8rem; }
+    .badges { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+    .badge { font-size: 0.72rem; padding: 0.25rem 0.75rem; border-radius: 5px; font-weight: 700; }
+    .badge-verified { background: rgba(44,85,48,0.12); color: var(--primary); border: 1px solid rgba(44,85,48,0.3); }
+    .badge-family { background: var(--surface2); color: var(--text-muted); border: 1px solid var(--border); }
+    .badge-hydro { background: rgba(200,160,48,0.15); color: #8A6800; border: 1px solid rgba(200,160,48,0.35); }
+
+    main { max-width: 900px; margin: 0 auto; padding: 2rem; }
+
+    .stage-tabs { display: flex; gap: 0.4rem; margin-bottom: 1.75rem; flex-wrap: wrap; }
+    .tab {
+      font-size: 0.8rem; padding: 0.4rem 1.1rem;
+      border-radius: 6px; border: 1px solid var(--border);
+      background: var(--bg); color: var(--text-muted);
+      cursor: pointer; font-weight: 600; transition: all 0.15s;
+    }
+    .tab.active { background: var(--primary); color: #fff; border-color: var(--primary); }
+    .tab:hover:not(.active) { border-color: var(--secondary); color: var(--secondary); }
+
+    .section-title {
+      font-size: 0.68rem; font-weight: 800; letter-spacing: 0.15em;
+      text-transform: uppercase; color: var(--text-muted); margin-bottom: 1rem;
+      padding-bottom: 0.5rem; border-bottom: 1px solid var(--border);
+    }
+
+    .param-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); gap: 0.75rem; margin-bottom: 2rem; }
+    .param-card {
+      background: var(--bg); border-radius: 10px;
+      padding: 1rem; border: 1px solid var(--border);
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .param-card:hover { border-color: var(--secondary); box-shadow: 0 2px 10px rgba(122,72,32,0.1); }
+    .param-label { font-size: 0.68rem; color: var(--text-muted); margin-bottom: 0.35rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
+    .param-value { font-size: 1.2rem; font-weight: 800; color: var(--primary); letter-spacing: -0.02em; }
+    .param-unit { font-size: 0.7rem; color: var(--text-muted); margin-top: 0.1rem; }
+
+    .nutrient-section { margin-bottom: 2rem; }
+    .nutrient-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.65rem; font-size: 0.85rem; }
+    .nutrient-label { width: 28px; font-weight: 800; color: var(--secondary); }
+    .nutrient-bar-bg { flex: 1; height: 7px; background: var(--surface2); border-radius: 4px; overflow: hidden; }
+    .nutrient-bar { height: 100%; background: linear-gradient(90deg, var(--primary), var(--accent)); border-radius: 4px; }
+    .nutrient-val { width: 70px; text-align: right; color: var(--text-muted); font-size: 0.8rem; }
+
+    .systems { display: flex; gap: 0.65rem; flex-wrap: wrap; margin-bottom: 2rem; }
+    .system-chip { font-size: 0.78rem; padding: 0.38rem 0.9rem; border-radius: 6px; font-weight: 700; }
+    .system-yes { background: rgba(44,85,48,0.1); color: var(--primary); border: 1px solid rgba(44,85,48,0.25); }
+    .system-no  { background: var(--surface); color: var(--border); border: 1px solid var(--border); text-decoration: line-through; }
+
+    .taxonomy { background: var(--bg); border-radius: 10px; padding: 1.25rem; border: 1px solid var(--border); margin-bottom: 2rem; }
+    .tax-row { display: flex; gap: 1rem; font-size: 0.85rem; padding: 0.35rem 0; border-bottom: 1px solid var(--surface2); }
+    .tax-row:last-child { border-bottom: none; }
+    .tax-key { width: 100px; color: var(--text-muted); font-weight: 600; }
+    .tax-val { font-weight: 700; color: var(--text); }
+
+    .quality-bar-wrap { background: var(--bg); border: 1px solid var(--border); border-radius: 10px; padding: 1rem 1.25rem; margin-bottom: 2rem; }
+    .quality-bar-bg { background: var(--surface2); border-radius: 4px; height: 8px; margin-top: 0.5rem; }
+    .quality-bar-fill { height: 100%; border-radius: 4px; background: var(--accent); width: 72%; }
+    .quality-label { font-size: 0.78rem; color: var(--text-muted); margin-top: 0.4rem; }
+
+    .community-box { background: var(--surface); border-radius: 12px; padding: 1.5rem; border: 1px solid var(--border); margin-bottom: 2rem; }
+    .community-box h3 { font-size: 0.95rem; font-weight: 700; margin-bottom: 1rem; color: var(--primary); }
+    .comment { display: flex; gap: 0.75rem; margin-bottom: 0.9rem; }
+    .avatar { width: 36px; height: 36px; border-radius: 50%; background: var(--secondary); display: flex; align-items: center; justify-content: center; font-weight: bold; font-size: 0.8rem; color: #fff; flex-shrink: 0; }
+    .comment-body { background: var(--bg); border-radius: 8px; padding: 0.6rem 0.9rem; border: 1px solid var(--border); font-size: 0.83rem; flex: 1; }
+    .comment-meta { font-size: 0.72rem; color: var(--text-muted); margin-bottom: 0.2rem; }
+
+    footer { background: var(--primary); color: rgba(255,255,255,0.5); text-align: center; padding: 1.5rem; font-size: 0.8rem; border-top: 3px solid var(--accent); }
+    footer span { color: var(--accent); font-weight: 700; }
+  </style>
+</head>
+<body>
+
+<nav>
+  <div class="logo">flower<span>chino</span></div>
+  <ul>
+    <li><a href="#">Plants</a></li>
+    <li><a href="#">API</a></li>
+    <li><a href="#">Community</a></li>
+    <li><a class="nav-login" href="#">Login</a></li>
+  </ul>
+</nav>
+
+<div class="hero">
+  <div class="hero-inner">
+    <div class="plant-icon">🍅</div>
+    <div class="hero-meta">
+      <h1>Tomato</h1>
+      <div class="binomial">Solanum lycopersicum L.</div>
+      <div class="badges">
+        <span class="badge badge-verified">✓ Community Verified</span>
+        <span class="badge badge-family">Solanaceae</span>
+        <span class="badge badge-hydro">Hydroponics</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<main>
+  <div class="stage-tabs">
+    <div class="tab">Germinating</div>
+    <div class="tab">Seedling</div>
+    <div class="tab">Vegetative</div>
+    <div class="tab active">Flowering</div>
+    <div class="tab">Fruiting</div>
+    <div class="tab">Harvesting</div>
+  </div>
+
+  <div class="section-title">Hydroponics Parameters — Flowering</div>
+  <div class="param-grid">
+    <div class="param-card"><div class="param-label">pH</div><div class="param-value">5.8–6.2</div></div>
+    <div class="param-card"><div class="param-label">EC</div><div class="param-value">2.5–3.5</div><div class="param-unit">mS/cm</div></div>
+    <div class="param-card"><div class="param-label">TDS</div><div class="param-value">1250–1750</div><div class="param-unit">ppm</div></div>
+    <div class="param-card"><div class="param-label">Water Temp</div><div class="param-value">18–22</div><div class="param-unit">°C</div></div>
+    <div class="param-card"><div class="param-label">Air Temp</div><div class="param-value">20–26</div><div class="param-unit">°C</div></div>
+    <div class="param-card"><div class="param-label">Humidity</div><div class="param-value">50–65</div><div class="param-unit">%</div></div>
+    <div class="param-card"><div class="param-label">VPD</div><div class="param-value">1.0–1.5</div><div class="param-unit">kPa</div></div>
+    <div class="param-card"><div class="param-label">PPFD</div><div class="param-value">500–700</div><div class="param-unit">µmol/m²/s</div></div>
+    <div class="param-card"><div class="param-label">Photoperiod</div><div class="param-value">16</div><div class="param-unit">hours</div></div>
+    <div class="param-card"><div class="param-label">DO</div><div class="param-value">≥ 8</div><div class="param-unit">mg/L</div></div>
+  </div>
+
+  <div class="section-title">Nutrient Profile</div>
+  <div class="nutrient-section">
+    <div class="nutrient-row"><span class="nutrient-label">N</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:55%"></div></div><span class="nutrient-val">120 ppm</span></div>
+    <div class="nutrient-row"><span class="nutrient-label">P</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:35%"></div></div><span class="nutrient-val">70 ppm</span></div>
+    <div class="nutrient-row"><span class="nutrient-label">K</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:90%"></div></div><span class="nutrient-val">250 ppm</span></div>
+    <div class="nutrient-row"><span class="nutrient-label">Ca</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:65%"></div></div><span class="nutrient-val">160 ppm</span></div>
+    <div class="nutrient-row"><span class="nutrient-label">Mg</span><div class="nutrient-bar-bg"><div class="nutrient-bar" style="width:25%"></div></div><span class="nutrient-val">50 ppm</span></div>
+  </div>
+
+  <div class="section-title">Grow System Compatibility</div>
+  <div class="systems">
+    <span class="system-chip system-yes">✓ DWC</span>
+    <span class="system-chip system-yes">✓ NFT</span>
+    <span class="system-chip system-yes">✓ Drip</span>
+    <span class="system-chip system-yes">✓ Ebb &amp; Flow</span>
+    <span class="system-chip system-no">Kratky</span>
+    <span class="system-chip system-no">Wicking</span>
+  </div>
+
+  <div class="section-title">Taxonomy</div>
+  <div class="taxonomy">
+    <div class="tax-row"><span class="tax-key">Kingdom</span><span class="tax-val">Plantae</span></div>
+    <div class="tax-row"><span class="tax-key">Family</span><span class="tax-val">Solanaceae</span></div>
+    <div class="tax-row"><span class="tax-key">Genus</span><span class="tax-val">Solanum</span></div>
+    <div class="tax-row"><span class="tax-key">Species</span><span class="tax-val">S. lycopersicum</span></div>
+    <div class="tax-row"><span class="tax-key">IPNI ID</span><span class="tax-val">320035-2</span></div>
+    <div class="tax-row"><span class="tax-key">GBIF Key</span><span class="tax-val">5284517</span></div>
+  </div>
+
+  <div class="section-title">Data Quality</div>
+  <div class="quality-bar-wrap">
+    <div style="display:flex;justify-content:space-between;font-size:0.85rem;">
+      <span>Completeness</span><span style="font-weight:800;color:var(--accent)">72%</span>
+    </div>
+    <div class="quality-bar-bg"><div class="quality-bar-fill"></div></div>
+    <div class="quality-label">Community Verified · Last reviewed 3 days ago · 12 contributors</div>
+  </div>
+
+  <div class="section-title">Community</div>
+  <div class="community-box">
+    <h3>💬 Discussion</h3>
+    <div class="comment">
+      <div class="avatar">MG</div>
+      <div class="comment-body"><div class="comment-meta">MaxGrower · 2 days ago</div>EC during late flowering can go up to 4.0 without stress if you ramp slowly over a week.</div>
+    </div>
+    <div class="comment">
+      <div class="avatar">SH</div>
+      <div class="comment-body"><div class="comment-meta">SarahHydro · 1 day ago</div>Confirmed. I run 3.8 in fruiting stage, massive yield difference compared to 2.5.</div>
+    </div>
+  </div>
+</main>
+
+<footer>© 2026 <span>Flowerchino</span> · Elastic License 2.0</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add two Vienna layout variants as HTML demos (scroll + sidebar)
- Document chosen color palette, CSS tokens and design principles
- Provide index page for design reference at `/design/`

## Notes
Vienna is the selected design direction for Flowerchino. These demos serve as the visual reference for all future UI implementation (Twig + Tailwind).